### PR TITLE
acs login, acs app remove, acs demo lbweb and improvements to SSH tunnel

### DIFF
--- a/acs/cli.py
+++ b/acs/cli.py
@@ -8,6 +8,7 @@ Options:
   -h --help                           Show this help.
 
 Commands:
+  login      Login to Azure interactively
   service    Create and manage Azure Container Service
   app        Deploy and manage applications in the cluster
   lb         Manage the Agents load balancer
@@ -29,6 +30,7 @@ from acs.commands.base import Config
 from docopt import docopt
 from inspect import getmembers, isclass
 import os.path
+import subprocess
 import sys
 
 def main():
@@ -39,6 +41,10 @@ def main():
 
   config = Config(args['--config-file'])
   command_name = args["<command>"]
+  if command_name == "login":
+    print(login())
+    return
+    
   argv = args['<args>']
   module = getattr(commands, command_name)
   commands = getmembers(module, isclass)
@@ -50,3 +56,15 @@ def main():
   if command is None:
     raise Exception("Unrecognized command: " + command_name)
   command.run()
+
+def login():
+  p = subprocess.Popen(["azure", "account", "show"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+  output, errors = p.communicate()
+  if errors:
+    # Not currently logged in
+  
+    p = subprocess.Popen(["azure", "login"], stderr=subprocess.PIPE)
+    output, errors = p.communicate()
+    if errors:
+      return "Failed to login: " + errors.decode("utf-8")
+  return "Logged in to Azure"

--- a/acs/commands/app.py
+++ b/acs/commands/app.py
@@ -7,6 +7,7 @@ Usage:
 
 Commands:
   deploy                deploy an application described by the appropriate app configuration
+  remove                remove an application described by the appropriate app configuration from the cluster
 
 Options:
   --app-config=<file>   the application configuration (compose file for Docker Swarm, Marhon JSON for DC/OS).
@@ -20,6 +21,7 @@ Help:
 
 from docopt import docopt
 from inspect import getmembers, ismethod
+import json
 from json import dumps
 import os
 import subprocess as sub 
@@ -27,11 +29,12 @@ import subprocess as sub
 from .base import Base
 
 class App(Base):
+  app_config_dir = "~/.acs/app/"
 
   def run(self):
     args = docopt(__doc__, argv=self.options)
-    # print("Command args")
-    # print(args)
+    # self.log.debug("App options:" + str(self.options))
+    # self.log.debug("App args:" + str(args))
     self.args = args
 
     command = self.args["<command>"]
@@ -51,17 +54,19 @@ class App(Base):
   def help(self):
     print(__doc__)
 
-  def deploy(self):
-    app_config_dir = "~/.acs/app/"
-
-    config_path = self.args["--app-config"]
+  def parseAppConfig(self, config_path):
+    """
+    Parse a use provided application configuration, replacing any
+    tokens that appear within it as appropriate. The parsed file
+    will be stored in `~/.acs/app/config/`.
+    """
     if not config_path:
       self.log.error("--app-config not supplied, unable to deploy application")
-      return "Must provide an application config file as '--app-config'"
-    
+      raise IOError("Must provide an application config file as '--app-config'")
+
     self.log.debug("Deploying application described by " + config_path)
     config_filename = os.path.expanduser(config_path)
-    perm_filename = os.path.expanduser(app_config_dir + config_filename)
+    perm_filename = os.path.expanduser(self.app_config_dir + config_filename)
     os.makedirs(os.path.dirname(perm_filename), exist_ok=True)
 
     tmpl = open(config_filename)
@@ -73,11 +78,42 @@ class App(Base):
     tmpl.close()
     output.close()
 
+    return perm_filename
+    
+  def deploy(self):
+    config_path = self.args["--app-config"]
+    try:
+      perm_filename = self.parseAppConfig(config_path)
+    except IOError as e:
+      self.log.error(str(e))
+      return "Unable to deploy application. There is a problem with the app configuration file. See the log for full details."
+
     p = sub.Popen(['dcos', 'marathon', 'app', "add", perm_filename],stdout=sub.PIPE,stderr=sub.PIPE)
     output, errors = p.communicate()
     if errors:
-      self.log.error("Error deploying applicatoin:\n" + errors.decode("utf-8"))
+      self.log.error("Error deploying application:\n" + errors.decode("utf-8"))
       return "Unable to deploy application, see log for full details."
     self.log.debug("Application deployed. Configuration stored in " + perm_filename)
 
     return "Application deployed"
+
+  def remove(self):
+    config_path = self.args["--app-config"]
+    try:
+      perm_filename = self.parseAppConfig(config_path)
+      with open(perm_filename) as app_config: 
+        app = json.load(app_config)
+        app_id = app["id"]
+    except IOError as e:
+      self.log.error(e)
+      return "Unable to remove application because: " + str(e) + ". See the log for full details."
+
+    self.log.debug("Removing app with the ID " + app_id)
+    p = sub.Popen(['dcos', 'marathon', 'app', "remove", app_id],stdout=sub.PIPE,stderr=sub.PIPE)
+    output, errors = p.communicate()
+    if errors:
+      self.log.error("Error removing application:\n" + errors.decode("utf-8"))
+      return "Unable to remove application, see log for full details."
+    self.log.debug("Application removed. Configuration stored in " + perm_filename)
+
+    return "Application removed."

--- a/acs/commands/base.py
+++ b/acs/commands/base.py
@@ -143,7 +143,13 @@ class Base(object):
 
     return data
 
-
+  def shell_execute(self, cmd):
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                         stderr=subprocess.PIPE, shell=True)
+    output, errors = p.communicate()
+    if errors:
+      self.log.error("Error executing shell command:\n" + errors.decode("utf-8"))
+    return output, errors
 
 
 

--- a/docs/source/demo/web.rst
+++ b/docs/source/demo/web.rst
@@ -3,14 +3,23 @@ How to Create a Web Server in Azure Container Service
 
 In this tuturial we will show how to use the CLI to create a simple,
 load balanced, static web server using the Azure Container
-Service CLI.
+Service CLI
 
+If you simply want to show a load balanced web application working
+then you can do everything you need, including deploying an instance
+of Azure Container Service, using a single command::
+
+  acs demo lbweb
+
+If you want to demonstrate the steps involved then this command can be
+expanded out to individual steps, as decribed below.
+  
 ACS powered by DC/OS
 --------------------
 
 First we need to create our cluster and open the tunnel::
 
-  azure login
+  acs login
   acs service create
   acs service openTunnel
 


### PR DESCRIPTION
# New commands

  * `acs login` to log the user into azure
  * `acs app remove` to remove a deployed application
  * ` acs demo lbweb` install a load balancer and deploy a simple load balanced web app

# Enhancements

  * Only create an SSH tunnel when there isn't already one available
  * Make it easier to discover the PID of the SSH tunnel so that it can be killed

